### PR TITLE
Add Requesty as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,19 @@ api_key = "sk-or-v1-..."
 # or: api_key_cmd = "op read 'op://Vault/OpenRouter/credential'"
 ```
 
-Environment variable fallback is supported: `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`.
+Or use [Requesty](https://requesty.ai) as your provider:
+
+```toml
+[provider]
+default = "requesty"
+model = "openai/gpt-4o-mini"
+
+[provider.requesty]
+api_key = "rqsty-sk-..."
+# or: api_key_cmd = "op read 'op://Vault/Requesty/credential'"
+```
+
+Environment variable fallback is supported: `OPENROUTER_API_KEY`, `REQUESTY_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`.
 
 ### 2. Enable shell integration
 
@@ -564,6 +576,11 @@ timeout_seconds = 120
 # api_key = "..."
 # api_key_cmd = "..."
 # base_url = "https://openrouter.ai/api/v1"
+
+[provider.requesty]
+# api_key = "rqsty-sk-..."
+# api_key_cmd = "..."
+# base_url = "https://router.requesty.ai/v1"
 
 [provider.anthropic]
 # api_key = "..."

--- a/install.sh
+++ b/install.sh
@@ -266,6 +266,7 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
         echo ""
         info "nsh needs an LLM provider API key."
         echo "  Get an OpenRouter key at: https://openrouter.ai/keys"
+        echo "  Or a Requesty key at:     https://requesty.ai"
         echo ""
         printf "  Enter your API key (or press Enter to skip): "
         read -r api_key
@@ -276,6 +277,9 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
     if [[ "$api_key" == sk-ant-* ]]; then
         PROVIDER="anthropic"
         MODEL="claude-sonnet-4-20250514"
+    elif [[ "$api_key" == rqsty-sk-* ]]; then
+        PROVIDER="requesty"
+        MODEL="openai/gpt-4o-mini"
     elif [[ "$api_key" == sk-* ]] && [[ "$api_key" != sk-or-* ]]; then
         PROVIDER="openai"
         MODEL="gpt-4.1-nano"

--- a/src/config.rs
+++ b/src/config.rs
@@ -418,6 +418,7 @@ pub struct ProviderConfig {
     #[deprecated(note = "use [web_search].model instead")]
     pub web_search_model: String,
     pub openrouter: Option<ProviderAuth>,
+    pub requesty: Option<ProviderAuth>,
     pub anthropic: Option<ProviderAuth>,
     pub openai: Option<ProviderAuth>,
     pub ollama: Option<ProviderAuth>,
@@ -447,6 +448,7 @@ impl Default for ProviderConfig {
             fallback_model: Some(model_defaults::DEFAULT_FALLBACK_MODEL.into()),
             web_search_model: model_defaults::DEFAULT_WEB_SEARCH_MODEL.into(),
             openrouter: Some(ProviderAuth::default()),
+            requesty: None,
             anthropic: None,
             openai: None,
             ollama: None,
@@ -502,6 +504,7 @@ impl ProviderAuth {
         }
         let env_var = match provider_name {
             "openrouter" => "OPENROUTER_API_KEY",
+            "requesty" => "REQUESTY_API_KEY",
             "anthropic" => "ANTHROPIC_API_KEY",
             "openai" => "OPENAI_API_KEY",
             "gemini" => "GEMINI_API_KEY",
@@ -1486,6 +1489,7 @@ fn append_provider_section(x: &mut String, config: &Config) {
     x.push_str("    <configured_providers>\n");
     for (name, auth) in [
         ("openrouter", &config.provider.openrouter),
+        ("requesty", &config.provider.requesty),
         ("anthropic", &config.provider.anthropic),
         ("openai", &config.provider.openai),
         ("ollama", &config.provider.ollama),
@@ -2644,6 +2648,30 @@ base_url = "https://oai.example.com"
 
         assert!(config.provider.ollama.is_none());
         assert!(config.provider.gemini.is_none());
+    }
+
+    #[test]
+    fn test_requesty_provider_config_parses() {
+        let toml_str = r#"
+[provider]
+default = "requesty"
+model = "openai/gpt-4o-mini"
+
+[provider.requesty]
+api_key_cmd = "printf requesty-provider-key"
+base_url = "https://router.requesty.ai/v1"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.provider.default, "requesty");
+        assert_eq!(config.provider.model, "openai/gpt-4o-mini");
+
+        let rq = config.provider.requesty.unwrap();
+        assert!(rq.api_key.is_none());
+        assert_eq!(
+            rq.api_key_cmd.as_deref(),
+            Some("printf requesty-provider-key")
+        );
+        assert_eq!(rq.base_url.as_deref(), Some("https://router.requesty.ai/v1"));
     }
 
     #[test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -5,6 +5,7 @@ pub mod openai;
 pub mod openai_compat;
 pub mod openrouter;
 pub mod policy;
+pub mod requesty;
 pub mod routing;
 
 use serde::{Deserialize, Serialize};

--- a/src/provider/requesty.rs
+++ b/src/provider/requesty.rs
@@ -1,0 +1,74 @@
+use super::openai_compat::OpenAICompatProviderConfig;
+use crate::config::ProviderConfig;
+pub fn build_requesty_compat_config(
+    provider: &ProviderConfig,
+) -> anyhow::Result<OpenAICompatProviderConfig> {
+    let auth = provider
+        .requesty
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Requesty not configured"))?;
+    Ok(OpenAICompatProviderConfig {
+        api_key: auth.resolve_api_key("requesty")?,
+        base_url: auth
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "https://router.requesty.ai/v1".into()),
+        strip_provider_prefix: false,
+        fallback_model: provider.fallback_model.clone(),
+        extra_headers: vec![
+            (
+                "HTTP-Referer".into(),
+                "https://github.com/fluffypony/nsh".into(),
+            ),
+            ("X-Title".into(), "nsh".into()),
+        ],
+        timeout_seconds: provider.timeout_seconds,
+        debug_provider_name: "requesty".to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_config_fails_when_requesty_not_configured() {
+        let provider = crate::config::ProviderConfig {
+            requesty: None,
+            ..Default::default()
+        };
+        let result = build_requesty_compat_config(&provider);
+        let err = result.err().expect("should fail when requesty is None");
+        assert!(err.to_string().contains("Requesty not configured"));
+    }
+
+    #[test]
+    fn build_config_uses_custom_base_url_when_provided() {
+        let provider = crate::config::ProviderConfig {
+            requesty: Some(crate::config::ProviderAuth {
+                api_key: Some("test-key".into()),
+                api_key_cmd: None,
+                base_url: Some("https://custom.example.com/v1".into()),
+            }),
+            ..Default::default()
+        };
+        let cfg = build_requesty_compat_config(&provider).expect("config should build");
+        assert_eq!(cfg.base_url, "https://custom.example.com/v1");
+        assert_eq!(cfg.debug_provider_name, "requesty");
+    }
+
+    #[test]
+    fn build_config_uses_default_base_url() {
+        let provider = crate::config::ProviderConfig {
+            requesty: Some(crate::config::ProviderAuth {
+                api_key: Some("test-key".into()),
+                api_key_cmd: None,
+                base_url: None,
+            }),
+            ..Default::default()
+        };
+        let cfg = build_requesty_compat_config(&provider).expect("config should build");
+        assert_eq!(cfg.base_url, "https://router.requesty.ai/v1");
+        assert_eq!(cfg.debug_provider_name, "requesty");
+    }
+}

--- a/src/provider/routing.rs
+++ b/src/provider/routing.rs
@@ -31,6 +31,11 @@ pub fn resolve_openai_compat_config(
                 &config.provider,
             )?));
         }
+        "requesty" => {
+            return Ok(Some(super::requesty::build_requesty_compat_config(
+                &config.provider,
+            )?));
+        }
         "openai" => {
             return Ok(Some(super::openai::build_openai_compat_config(
                 &config.provider,
@@ -174,6 +179,23 @@ mod tests {
         let resolved =
             resolve_openai_compat_config("unknown-provider", &cfg).expect("resolve should succeed");
         assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_openai_compat_config_requesty_uses_default_base_url() {
+        let mut config = crate::config::Config::default();
+        config.provider.requesty = Some(crate::config::ProviderAuth {
+            api_key: Some("rqsty-sk-test".into()),
+            api_key_cmd: None,
+            base_url: None,
+        });
+        let cfg = cfg_from(config);
+
+        let resolved = resolve_openai_compat_config("requesty", &cfg)
+            .expect("resolve should succeed")
+            .expect("config should resolve");
+        assert_eq!(resolved.base_url, "https://router.requesty.ai/v1");
+        assert_eq!(resolved.debug_provider_name, "requesty");
     }
 
     #[test]


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider, mirroring the existing OpenRouter provider.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router.

Changes:
- `src/provider/requesty.rs`: `build_requesty_compat_config` mirroring the OpenRouter one (default base URL `https://router.requesty.ai/v1`), with tests.
- `src/provider/mod.rs`, `routing.rs`: module + the `requesty` routing arm.
- `src/config.rs`: the `requesty` provider config field + env `REQUESTY_API_KEY` + a config-parse test.
- `README.md`, `install.sh`: docs + a `rqsty-sk-` key-prefix branch in the installer.

Verified: `cargo build` and the provider/config tests pass, `install.sh` passes `bash -n`.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.